### PR TITLE
Remove not necessary thread safe singleton

### DIFF
--- a/di_container.py
+++ b/di_container.py
@@ -1,5 +1,5 @@
 from dependency_injector.containers import DeclarativeContainer, WiringConfiguration
-from dependency_injector.providers import Dependency, Factory, ThreadSafeSingleton
+from dependency_injector.providers import Dependency, Factory, Singleton
 from sqlalchemy_bind_manager import SQLAlchemyBindManager
 
 from config import AppConfig
@@ -33,7 +33,7 @@ class Container(DeclarativeContainer):
     These are classes we want the container to manage the life cycle for
     (e.g. Singletons), we map them using their class name directly.
     """
-    SQLAlchemyBindManager = ThreadSafeSingleton(
+    SQLAlchemyBindManager = Singleton(
         SQLAlchemyBindManager,
         config=config.provided.SQLALCHEMY_CONFIG,
     )


### PR DESCRIPTION
It's not necessary to use a thread safe singleton, it would only increase the number of connections by generating one engine per thread, therefore multiple connection pools. A normal singleton and a single connection pool among all threads is enough.