### PR TITLE
Make sure processes run as PID 1 to correctly handle signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,10 @@ ENTRYPOINT ["poetry", "run"]
 FROM base_app as http_app
 COPY --from=http_builder /poetryvenvs /poetryvenvs
 COPY http_app ./http_app
-CMD ["make", "run"]
+CMD exec opentelemetry-instrument uvicorn http_app:create_app --host 0.0.0.0 --port 8000 --factory
 
 # Copy the grpc python package and requirements from relevant builder
 FROM base_app as grpc_app
 COPY --from=grpc_builder /poetryvenvs /poetryvenvs
 COPY grpc_app ./grpc_app
-CMD ["make", "grpc"]
+CMD exec opentelemetry-instrument python3 -m grpc_app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,7 @@
 version: '3.8'
 services:
+  # We don't use `make` or `poetry` for long running processes,
+  # to make sure they run as pid 1 and receive SIGTERM signal
   dev:
     build:
       dockerfile: Dockerfile
@@ -7,7 +9,15 @@ services:
       target: http_app
     ports:
       - '8000:8000'
-    command: ["make", "dev"]
+    command:
+      - "uvicorn"
+      - "http_app:create_app"
+      - "--host"
+      - "0.0.0.0"
+      - "--port"
+      - "8000"
+      - "--factory"
+      - "--reload"
     volumes:
       - '.:/app'
   http:
@@ -20,20 +30,10 @@ services:
       OTEL_TRACES_EXPORTER: "console"
       OTEL_METRICS_EXPORTER: "console"
       OTEL_LOGS_EXPORTER: "none"
-    command: ["opentelemetry-instrument", "make", "run"]
     ports:
       - '8001:8000'
     volumes:
       - './sqlite.db:/app/sqlite.db'
-
-  generate-proto:
-    build:
-      dockerfile: Dockerfile
-      context: .
-      target: grpc_builder
-    volumes:
-      - '.:/app'
-    command: ["make", "generate-proto"]
 
   grpc:
     build:
@@ -45,11 +45,22 @@ services:
       OTEL_TRACES_EXPORTER: "console"
       OTEL_METRICS_EXPORTER: "console"
       OTEL_LOGS_EXPORTER: "none"
-    command: ["opentelemetry-instrument", "make", "grpc"]
     ports:
       - "9999:9999"
     volumes:
       - '.:/app'
+
+  # Starting from here there are only single-run commands, we can use `make` here
+  generate-proto:
+    build:
+      dockerfile: Dockerfile
+      context: .
+      target: grpc_builder
+    volumes:
+      - '.:/app'
+    command:
+      - "make"
+      - "generate-proto"
 
   test:
     build:
@@ -58,11 +69,15 @@ services:
       target: test
     volumes:
       - '.:/app'
-    command: ["make", "test"]
+    command:
+      - "make"
+      - "test"
 
   ci-test:
     build:
       dockerfile: Dockerfile
       context: .
       target: test
-    command: ["make", "test"]
+    command:
+      - "make"
+      - "ci-test"

--- a/grpc_app/__init__.py
+++ b/grpc_app/__init__.py
@@ -1,9 +1,9 @@
-import logging
 import os
 from concurrent import futures
 from typing import Optional
 
 from grpc.aio import server
+from structlog import get_logger
 
 from config import AppConfig, init_logger
 from domains import init_domains
@@ -13,7 +13,7 @@ from storage import init_storage
 
 
 # TODO: Add asyncio support: https://stackoverflow.com/questions/38387443/how-to-implement-a-async-grpc-python-server
-def create_server(test_config: Optional[AppConfig] = None):
+async def create_server(test_config: Optional[AppConfig] = None):
     app_config = test_config or AppConfig()
     init_logger(app_config)
     init_domains(app_config)
@@ -22,13 +22,15 @@ def create_server(test_config: Optional[AppConfig] = None):
     # Register service
     add_BooksServicer_to_server(BooksServicer(), s)
     address = "0.0.0.0:9999"
-    logging.info(f"[{os.getpid()}] Listening on {address}")
+    logger = get_logger()
+    logger.ainfo(f"[{os.getpid()}] Listening on {address}")
     s.add_insecure_port(address)
     return s
 
 
 async def main():  # pragma: no cover
-    s = create_server()
+    s = await create_server()
     await s.start()
-    logging.info("GRPC started")
+    logger = get_logger()
+    await logger.ainfo("GRPC started")
     await s.wait_for_termination()

--- a/grpc_app/__init__.py
+++ b/grpc_app/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from concurrent import futures
 from typing import Optional
 
@@ -20,12 +21,14 @@ def create_server(test_config: Optional[AppConfig] = None):
     s = server(futures.ThreadPoolExecutor(max_workers=10))
     # Register service
     add_BooksServicer_to_server(BooksServicer(), s)
-    s.add_insecure_port("0.0.0.0:9999")
+    address = "0.0.0.0:9999"
+    logging.info(f"[{os.getpid()}] Listening on {address}")
+    s.add_insecure_port(address)
     return s
 
 
 async def main():  # pragma: no cover
     s = create_server()
     await s.start()
-    await s.wait_for_termination()
     logging.info("GRPC started")
+    await s.wait_for_termination()

--- a/http_app/__init__.py
+++ b/http_app/__init__.py
@@ -53,5 +53,5 @@ def init_exception_handlers(app: FastAPI) -> None:
             return await call_next(request)
         except Exception as e:
             logger = get_logger(__name__)
-            logger.exception(e)
+            await logger.aexception(e)
             return JSONResponse({"error": "Internal server error"}, status_code=500)

--- a/tests/grpc_app/test_factory.py
+++ b/tests/grpc_app/test_factory.py
@@ -10,6 +10,6 @@ from grpc_app import create_server
 @pytest.mark.parametrize("test_config", [AppConfig(SQLALCHEMY_CONFIG={}), None])
 async def test_factory_returns_server(test_config):
     with patch("grpc_app.init_storage", return_value=None):
-        server = create_server(test_config=test_config)
+        server = await create_server(test_config=test_config)
 
     assert isinstance(server, Server)

--- a/tests/http_app/test_exception_handlers.py
+++ b/tests/http_app/test_exception_handlers.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI
 from httpx import AsyncClient
@@ -15,7 +15,7 @@ async def test_exception_is_logged_handler_returns_500(
     async def fake_endpoint():
         raise my_exc
 
-    mocked_get_logger.return_value.exception = MagicMock(return_value=None)
+    mocked_get_logger.return_value.aexception = AsyncMock(return_value=None)
 
     async with AsyncClient(app=testapp, base_url="http://test") as ac:
         response = await ac.get("/ppp")
@@ -23,4 +23,4 @@ async def test_exception_is_logged_handler_returns_500(
     assert response.status_code == 500
     assert response.json() == {"error": "Internal server error"}
     mocked_get_logger.assert_called_once()
-    mocked_get_logger.return_value.exception.assert_called_once_with(my_exc)
+    mocked_get_logger.return_value.aexception.assert_called_once_with(my_exc)


### PR DESCRIPTION
- Make sure processes run as PID 1 to correctly handle signals
- Use Async logger