### PR TITLE
Remove UV constraint version

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,9 +34,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-        with:
-          # Install a specific version of uv.
-          version: "0.5.13"
 
       - name: Install dependencies
         run: make dev-dependencies

--- a/.github/workflows/python-code-style.yml
+++ b/.github/workflows/python-code-style.yml
@@ -23,9 +23,6 @@ jobs:
         python-version: "3.13"
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-      with:
-        # Install a specific version of uv.
-        version: "0.5.13"
     - name: Install dependencies
       run: make dev-dependencies
     - name: Check code style

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -23,9 +23,6 @@ jobs:
         python-version: "3.13"
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-      with:
-        # Install a specific version of uv.
-        version: "0.5.13"
     - name: Install dependencies
       run: make dev-dependencies
     - name: Lint with ruff

--- a/.github/workflows/python-quality.yml
+++ b/.github/workflows/python-quality.yml
@@ -23,9 +23,6 @@ jobs:
         python-version: "3.13"
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-      with:
-        # Install a specific version of uv.
-        version: "0.5.13"
     - name: Install dependencies
       run: make dev-dependencies
     - name: Test & publish code coverage

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,9 +26,6 @@ jobs:
         python-version: "${{ matrix.version }}"
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-      with:
-        # Install a specific version of uv.
-        version: "0.5.13"
     - name: Install dependencies
       run: make dev-dependencies
     - name: Test with pytest

--- a/.github/workflows/python-typing.yml
+++ b/.github/workflows/python-typing.yml
@@ -23,9 +23,6 @@ jobs:
         python-version: "3.13"
     - name: Install uv
       uses: astral-sh/setup-uv@v5
-      with:
-        # Install a specific version of uv.
-        version: "0.5.13"
     - name: Install dependencies
       run: make dev-dependencies
     - name: Check typing


### PR DESCRIPTION
Renovatebot does not upgrades that. We remove the constraint, it is anyway upgraded everywhere else